### PR TITLE
[Feat] OneWay에서 플레이어가 아래키를 누르면 내려가기

### DIFF
--- a/2DProject_Katana_ZERO/Assets/Scripts/Character/Player/PlayerController.cs
+++ b/2DProject_Katana_ZERO/Assets/Scripts/Character/Player/PlayerController.cs
@@ -32,7 +32,7 @@ public class PlayerController : Character
     private PlayerData _data;
     private PlayerAnimInvoker _animInvoker;
     private Rigidbody2D _rigid;
-    private Animator _anim;
+    private CapsuleCollider2D _capsule;
 
     public Transform CursorPosition;
     public event Action<bool> ExistAroundItem;
@@ -74,7 +74,7 @@ public class PlayerController : Character
         _input = GetComponent<PlayerInput>();
         _data = GetComponent<PlayerData>();
         _rigid = GetComponent<Rigidbody2D>();
-        _anim = GetComponent<Animator>();
+        _capsule = GetComponent<CapsuleCollider2D>();
         _animInvoker = GetComponent<PlayerAnimInvoker>();
         _effectManager = EffectManager.GetComponent<EffectManager>();
         _delayLaserDeathEffectTime = new WaitForSeconds( _delayLaserDeathTime );
@@ -394,5 +394,28 @@ public class PlayerController : Character
 
         gameObject.SetActive( false );
     }
-}
 
+    public void MoveToDownOnOneWay()
+    {
+        if ( _changeLayerCoroutine != null )
+        {
+            StopCoroutine( _changeLayerCoroutine );
+        }
+
+        _changeLayerCoroutine = ChangeLayer();
+        StartCoroutine( _changeLayerCoroutine );
+    }
+
+    private IEnumerator _changeLayerCoroutine;
+
+    private IEnumerator ChangeLayer()
+    {
+        gameObject.layer = LayerMaskNumber.s_PlayerOneWay;
+        _capsule.enabled = false;
+
+        yield return new WaitForSeconds( 0.15f );
+
+        gameObject.layer = LayerMaskNumber.s_Player;
+        _capsule.enabled = true;
+    }
+}

--- a/2DProject_Katana_ZERO/Assets/Scripts/Character/Player/PlayerStateBehaviour/PreCrouchStateBehaviour.cs
+++ b/2DProject_Katana_ZERO/Assets/Scripts/Character/Player/PlayerStateBehaviour/PreCrouchStateBehaviour.cs
@@ -11,7 +11,12 @@ public class PreCrouchStateBehaviour : PlayerState
 
         CurrentPlayerState = PlayerAnimInvoker.PlayerState.PreCrouch;
 
-        if ( data.PlayerOnGround == GlobalData.GroundState.Slope )
+        if ( data.PlayerOnGround == GlobalData.GroundState.OneWay)
+        {
+            controller.MoveToDownOnOneWay();
+            ChangeState( animator, PlayerAnimationHash.s_PreCrouch, PlayerAnimationHash.s_Fall );
+        }
+        else if( data.PlayerOnGround == GlobalData.GroundState.Slope )
         {
             rigid.constraints = RigidbodyConstraints2D.FreezePositionX | RigidbodyConstraints2D.FreezeRotation;
         }
@@ -25,6 +30,7 @@ public class PreCrouchStateBehaviour : PlayerState
     override public void OnStateExit(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
         base.OnStateExit( animator, stateInfo, layerIndex );
+
         rigid.constraints = RigidbodyConstraints2D.FreezeRotation;
     }
 }

--- a/2DProject_Katana_ZERO/Assets/Scripts/System/etc/Util/Helper/LiteralRepository.cs
+++ b/2DProject_Katana_ZERO/Assets/Scripts/System/etc/Util/Helper/LiteralRepository.cs
@@ -142,6 +142,7 @@ namespace LiteralRepository
         public static int s_FlatGround           = 19;
         public static int s_SlopeGround          = 20;
         public static int s_OneWayGround         = 21;
+        public static int s_PlayerOneWay         = 22;
     }
 
     public static class InputAxisString


### PR DESCRIPTION
# PR을 하기 전 체크사항
<!-- 체크 표시는 []에 x를 넣어 [x]로 만들면 됩니다. 자세한 건 [여기](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists)를 참고하세요 -->
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
- OneWay에서 플레이어가 아래키를 누르면 내려갑니다

# 제안 사항
- OneWay에서 플레이어가 아래키를 누르면 내려갑니다
> OneWayGround 위에서 PreCrouch 상태로 전이되는 순간 OneWay위에 서있다면, 잠시 Trigger를 키고, 레이어를 변경시켜줍니다 

# (선택)스크린샷
![녹화_2023_04_30_02_11_30_949_AdobeExpress](https://user-images.githubusercontent.com/120005202/235315312-cefcd29d-fa13-4ca8-bcbc-19f191b75d45.gif)

# (선택)관련 이슈
- #103 

---

# 코드 리뷰 가이드
코드 리뷰를 어떻게 해야하는지 모르겠다면 아래의 사항을 고려해보세요.

- 이름은 충분히 명확한가?
- 코드 흐름은 읽기 쉽게 되어 있는가?
  - 개행은 세부 로직 별로 잘 적용이 되어 있는가?
- 불필요한 객체가 존재하진 않는가?
  - 쓸데없는 Manager 객체가 존재하진 않는가?
- 객체 간 결합도는 충분히 낮은가?
- 불필요한 필드가 존재하진 않는가?
- 다른 객체를 참조할 때, Find()를 사용하고 있진 않은가?
  - Instantiate()를 활용해 참조를 얻어올 수 있진 않은가?
  - 전역적인 접근점을 지닌 다른 객체를 통해서 참조를 얻어올 수 있진 않은가?
- 과도하게 모듈화 되어 있진 않은가?
  - 하나의 함수로 작성할 수 있는 걸 구태여 여러 개로 분리하진 않았는가?
- [주석이 작성되어 있는가?](https://learn.microsoft.com/ko-kr/dotnet/csharp/language-reference/xmldoc/recommended-tags)
  - 모든 public 함수에 주석이 작성되어 있는가?
  - 코드만으로는 이해하기 어려운 부분에 주석이 작성되어 있는가?
- 함수는 하나의 일만 해결하고 있는가?
- Assert()로 사전 조건과 사후 조건을 모두 체크하고 있는가?
  - NullReferenceException이 발생할 만한 부분은 없는가?
